### PR TITLE
Configure logging system as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ timy_config.tracking = False
 ```
 
 #### Changing the way timy outputs information
-You can either use print or logging for all timy outputs, with the `tracking_mode` value.
+You can choose between print or logging for all timy outputs by setting the
+value of `tracking_mode`.
 > The default value of `tracking_mode` is `TrackingMode.PRINTING`.
 
 ```python
@@ -125,6 +126,19 @@ from timy.settings import (
 )
 
 timy_config.tracking_mode = TrackingMode.LOGGING
+```
+
+timy logs at the INFO level, which is not printed or stored by default. To
+configure the logging system to print all INFO messages do
+```
+import logging
+logging.basicConfig(level=logging.INFO)
+```
+or to configure the logging system to print only timy's INFO messages do
+```
+import logging
+logging.basicConfig()
+logging.getLogger('timy').level=logging.INFO
 ```
 
 ## Contribute

--- a/timy/__init__.py
+++ b/timy/__init__.py
@@ -6,9 +6,8 @@ from .settings import (
     TrackingMode
 )
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.addHandler(logging.NullHandler())
 
 
 def output(ident, text):


### PR DESCRIPTION
This changes the way timy sets up its logging system to avoid clobbering any other logging configured by the user. It also updates the readme to describe basic usage of logging.

This follows the recommendations of the [Python Cookbook (see "Adding Logging to Libraries")](http://chimera.labs.oreilly.com/books/1230000000393/ch13.html#_discussion_221), i.e. do not call `logging.basicConfig()`, do not set a logging level in library code, and allow the user of the library to configure logging themselves.

Re: #9, `logging.INFO` is semantically a reasonable level for timy to log at (so is `logging.DEBUG`). The choice is not a huge deal. The main issue is the correct use of the logging system, which allows logging levels to be set on a per-library basis.