### PR TITLE
Drop py2 support and add remaining tests 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.1
+      - image: themattrix/tox
 
     working_directory: ~/repo
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyo
 env
 env*
+.env
 dist
 build
 *.egg

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # timy
 
-![Python 2.7](https://img.shields.io/badge/python-2.7-blue.svg)
+![Python 3.5](https://img.shields.io/badge/python-3.5-blue.svg)
 ![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
 Minimalist measurement of python code time

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 tox
+pytest
+pytest-cov

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,11 +1,8 @@
 import logging
 
-import mock
+from unittest import mock
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import StringIO
 
 from timy import output
 from timy.settings import (

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -37,3 +37,9 @@ def test_output_logger_tracking():
     with mock.patch.object(logger, 'info') as p_info:
         output('ident', 'text')
         p_info.assert_called_with('ident text seconds')
+
+
+def test_output_invalid_tracking():
+    timy_config.tracking = True
+    timy_config.tracking_mode = -1
+    output('ident', 'text')

--- a/tests/test_timer_cp.py
+++ b/tests/test_timer_cp.py
@@ -16,3 +16,16 @@ def test_init():
 def test_init_sleeptime():
     timer = Timer(include_sleeptime=False)
     assert timer.time_func == time.process_time
+
+
+@mock.patch('timy.output')
+def test_cp(p_output):
+    _timer = Timer()
+
+    with mock.patch.object(_timer, 'time_func') as p_time_func:
+        p_time_func.return_value = 1
+        with _timer as timer:
+            pass
+        assert _timer.start == 1
+
+    p_output.assert_called_once_with(_timer.ident, '0.000000')

--- a/tests/test_timer_cp.py
+++ b/tests/test_timer_cp.py
@@ -29,3 +29,22 @@ def test_cp(p_output):
         assert _timer.start == 1
 
     p_output.assert_called_once_with(_timer.ident, '0.000000')
+
+
+def test_elapsed():
+    timer = Timer()
+    with mock.patch.object(timer, 'time_func') as p_time_func:
+        p_time_func.return_value = 1
+        elapsed = timer.elapsed
+        assert elapsed == 1
+
+
+@mock.patch('timy.output')
+def test_track(p_output):
+    timer = Timer()
+    with mock.patch(
+            'timy.Timer.elapsed', new_callable=mock.PropertyMock) as p_elapsed:
+        p_elapsed.return_value = 1
+        timer.track()
+        p_output.assert_called_once_with(
+            timer.ident, '(track) 1.000000')

--- a/tests/test_timer_cp.py
+++ b/tests/test_timer_cp.py
@@ -1,0 +1,18 @@
+import time
+
+from unittest import mock
+
+from timy import Timer
+from timy.settings import timy_config
+
+
+def test_init():
+    timer = Timer()
+    assert timer.ident == timy_config.DEFAULT_IDENT
+    assert timer.start == 0
+    assert timer.time_func == time.perf_counter
+
+
+def test_init_sleeptime():
+    timer = Timer(include_sleeptime=False)
+    assert timer.time_func == time.process_time

--- a/tests/test_timer_dec.py
+++ b/tests/test_timer_dec.py
@@ -1,0 +1,88 @@
+from unittest import mock
+
+from timy import timer
+from timy.settings import (
+    timy_config,
+    TrackingMode)
+
+
+@mock.patch('timy.output')
+def test_timer_no_tracking(p_output):
+    timy_config.tracking = False
+
+    @timer()
+    def func():
+        pass
+
+    func()
+    p_output.assert_not_called()
+
+
+@mock.patch('timy.output')
+@mock.patch('time.perf_counter')
+def test_timer_include_sleeptime(p_perf_counter, p_output):
+    timy_config.tracking = True
+
+    @timer()
+    def func():
+        pass
+
+    p_perf_counter.return_value = 1
+
+    func()
+
+    p_output.assert_has_calls([
+        mock.call(
+            timy_config.DEFAULT_IDENT,
+            'executed (func) for 1 time in 0.000000'),
+        mock.call(
+            timy_config.DEFAULT_IDENT,
+            'best time was 0.000000'),
+    ])
+
+
+@mock.patch('timy.output')
+@mock.patch('time.process_time')
+def test_timer_include_sleeptime(p_process_time, p_output):
+    timy_config.tracking = True
+
+    @timer(include_sleeptime=False)
+    def func():
+        pass
+
+    p_process_time.return_value = 1
+
+    func()
+
+    p_output.assert_has_calls([
+        mock.call(
+            timy_config.DEFAULT_IDENT,
+            'executed (func) for 1 time in 0.000000'),
+        mock.call(
+            timy_config.DEFAULT_IDENT,
+            'best time was 0.000000'),
+    ])
+
+
+@mock.patch('timy.output')
+@mock.patch('time.perf_counter')
+def test_timer_with_loops(p_perf_counter, p_output):
+    timy_config.tracking = True
+    LOOPS = 4
+
+    @timer(loops=LOOPS)
+    def func():
+        pass
+
+    p_perf_counter.return_value = 1
+
+    func()
+
+    p_output.assert_has_calls([
+        mock.call(
+            timy_config.DEFAULT_IDENT,
+            'executed (func) for {} times in 0.000000'.format(LOOPS)),
+        mock.call(
+            timy_config.DEFAULT_IDENT,
+            'best time was 0.000000'),
+    ])

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py27, py36
+envlist = py35, py36
 
 [testenv]
 deps =
-    mock
     pytest
     pytest-cov
     codecov


### PR DESCRIPTION
## Description

Drops py2 support and add remaining tests for the library.
`timy` is now tested under `py35` and `py36`, but should also work on any `py3+` release.